### PR TITLE
Run 5493 external window id updates

### DIFF
--- a/src/api/external-window/external-window.ts
+++ b/src/api/external-window/external-window.ts
@@ -2,7 +2,7 @@ import { _Window } from '../window/window';
 import { AnchorType, Bounds } from '../../shapes';
 import { Base, EmitterBase } from '../base';
 import { ExternalWindowEvents } from '../events/externalWindow';
-import { GroupWindowIdentity, Identity, ExternalWindowIdentity } from '../../identity';
+import { GroupWindowIdentity, Identity } from '../../identity';
 import Transport from '../../transport/transport';
 
 /**

--- a/src/api/external-window/external-window.ts
+++ b/src/api/external-window/external-window.ts
@@ -21,8 +21,11 @@ export default class ExternalWindowModule extends Base {
      * @tutorial Window.wrap
      */
     public async wrap(identity: Identity): Promise<ExternalWindow> {
-        await this.wire.sendAction('register-native-external-window', identity);
-        return new ExternalWindow(this.wire, identity);
+        const response = await this.wire.sendAction('register-native-external-window', identity);
+        // Allow core to provide uuid if none is provided by user,
+        // or nativeId when wrapping via a uuid obtained from `launchExternalProcess`
+        const identityFromCore = response.payload.data;
+        return new ExternalWindow(this.wire, identityFromCore);
     }
 }
 

--- a/src/api/system/external-process.ts
+++ b/src/api/system/external-process.ts
@@ -6,6 +6,7 @@ export interface ExternalProcessRequestType {
     listener?: LaunchExternalProcessListener;
     lifetime?: string;
     certificate?: CertificationInfo;
+    uuid?: string;
 }
 
 export interface CertificationInfo {

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -318,6 +318,24 @@ describe('System.', function () {
             .then(() => assert(true)));
     });
 
+    describe('getAllExternalWindows()', () => {
+        it('should not include uuids for unregistered windows', async () => {
+            const externalWindows = await fin.System.getAllExternalWindows();
+            const windowWithUuid = externalWindows.find(win => win.uuid);
+            assert(!windowWithUuid);
+        });
+        it('should include uuids for registered windows', async () => {
+            const externalProcess = await fin.System.launchExternalProcess({ path: 'notepad', uuid: 'trev' });
+            // TODO: remove this when the 'external-window-created' event is working properly
+            await new Promise(r => setTimeout(r, 300));
+            const wrapped = await fin.ExternalWindow.wrap(externalProcess);
+            const externalWindows = await fin.System.getAllExternalApplications();
+            const uuidFound = !!externalWindows.find(win => win.uuid === 'trev');
+            assert(uuidFound, 'Failed to find requested uuid assigned to external window');
+        });
+        it('should include nativeId for all windows');
+    })
+
     describe('resolveUuid()', () => {
         it('should resolve a known uuid', () => fin.System.resolveUuid(fin.me.uuid).then(data => {
             assert(data.uuid === fin.me.uuid, `Expected ${data.uuid} to match ${fin.me.uuid}`);

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -3,6 +3,7 @@ import { Fin } from '../src/main';
 import * as assert from 'assert';
 import { cleanOpenRuntimes } from './multi-runtime-utils';
 import { ExternalProcessRequestType, ExitCode } from '../src/api/system/external-process';
+import { ExternalWindow } from '../src/api/external-window/external-window';
 
 describe('System.', function () {
     let fin: Fin;
@@ -321,20 +322,59 @@ describe('System.', function () {
     describe('getAllExternalWindows()', () => {
         it('should not include uuids for unregistered windows', async () => {
             const externalWindows = await fin.System.getAllExternalWindows();
-            const windowWithUuid = externalWindows.find(win => win.uuid);
+            const windowWithUuid = externalWindows.find(win => !!win.uuid);
             assert(!windowWithUuid);
         });
-        it('should include uuids for registered windows', async () => {
-            const externalProcess = await fin.System.launchExternalProcess({ path: 'notepad', uuid: 'trev' });
-            // TODO: remove this when the 'external-window-created' event is working properly
-            await new Promise(r => setTimeout(r, 300));
-            const wrapped = await fin.ExternalWindow.wrap(externalProcess);
-            const externalWindows = await fin.System.getAllExternalApplications();
-            const uuidFound = !!externalWindows.find(win => win.uuid === 'trev');
-            assert(uuidFound, 'Failed to find requested uuid assigned to external window');
+        it('should include uuids for registered windows', (done) => {
+            let listener: (externalWindowInfo: any) => void;
+            let wrapped: ExternalWindow;
+            let timeout: NodeJS.Timer;
+            const cleanup = async () => {
+                clearTimeout(timeout);
+                if (wrapped) {
+                    wrapped.close();
+                }
+                fin.System.removeListener('external-window-shown', listener);
+            };
+            const runTest = () => {
+                // Returning a promise because Mocha tests will not fail gracefully if our
+                // assert fails in an event listener.
+                return new Promise(async (resolve, reject) => {
+                    const uuid = 'trev';
+                    listener = async (externalWindowInfo: any) => {
+                        if (externalWindowInfo.uuid === uuid) {
+                            wrapped = await fin.ExternalWindow.wrap(externalWindowInfo);
+                            const externalWindows = await fin.System.getAllExternalWindows();
+                            const uuidFound = !!externalWindows.find(win => win.uuid === uuid);
+                            resolve(uuidFound);
+                        }
+                    };
+                    await fin.System.addListener('external-window-shown', listener);
+                    await fin.System.launchExternalProcess({ path: 'notepad', uuid });
+                    timeout = setTimeout(async () => {
+                        await cleanup();
+                        assert(false, '"external-window-shown" event did not fire');
+                        done();
+                    }, 3000);
+                });
+            };
+            runTest()
+            .then(async uuidFound => {
+                await cleanup();
+                assert(uuidFound, 'Failed to find requested uuid assigned to external window');
+                done();
+            })
+            .catch(async err => {
+                await cleanup();
+                assert(false, err);
+                done();
+            });
         });
-        it('should include nativeId for all windows');
-    })
+        it('should include nativeId for all windows', async () => {
+            const externalWindows = await fin.System.getAllExternalWindows();
+            assert(externalWindows.every(win => win.hasOwnProperty('nativeId')));
+        });
+    });
 
     describe('resolveUuid()', () => {
         it('should resolve a known uuid', () => fin.System.resolveUuid(fin.me.uuid).then(data => {


### PR DESCRIPTION
#### Description of Change
Jira: https://appoji.jira.com/browse/RUN-5493

This change allows the core to set `uuid` and `nativeId` for ExternalWindows. This allows the user to wrap a native window by nativeId OR (a valid, already registered) uuid.

Related core PR: https://github.com/HadoukenIO/core/compare/develop...dhamberlin:RUN-5493-external-window-id-updates?expand=1

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
`ExternalWindow.wrap` can now wrap non-OpenFin windows using one of two properties:
- `nativeId` (obtained from e.g. `System.getAllExternalWindows`)
- `uuid` if a uuid has already been assigned to the window. For example if window was opened via `System.launchExternalProcess`
