### PR TITLE
[RUN-5626] Emit view-attached and view-detached events from View to Window

### DIFF
--- a/src/api/events/window.ts
+++ b/src/api/events/window.ts
@@ -163,6 +163,8 @@ export interface WindowEventMapping<Topic = string, Type = string> extends WebCo
     'shown': WindowEvent<Topic, Type>;
     'user-movement-disabled': WindowEvent<Topic, Type>;
     'user-movement-enabled': WindowEvent<Topic, Type>;
+    'view-attached': WindowEvent<Topic, Type>;
+    'view-detached': WindowEvent<Topic, Type>;
     'will-move': WillMoveOrResize<Topic, Type>;
     'will-resize': WillMoveOrResize<Topic, Type>;
 }

--- a/tutorials/Window.EventEmitter.md
+++ b/tutorials/Window.EventEmitter.md
@@ -109,6 +109,8 @@ finWindow.removeAllListeners("bounds-changed");
 * shown
 * user-movement-disabled
 * user-movement-enabled
+* view-attached
+* view-detached
 * will-move
 * will-resize
 
@@ -725,6 +727,36 @@ Generated when a window's user movement becomes enabled.
     topic: "window",
     type: "user-movement-enabled",
     uuid: "AppUUID" //(string) the UUID of the application the window belongs to.
+}
+```
+
+#### view-attached
+Generated when a window has a view attached to it.
+```js
+//This response has the following shape:
+{
+    name: "windowOne" // the name of this Window
+    previousTarget: {uuid: 'previousWindowUuid', name: 'previousWindowName'}, // the identity of the window this BrowserView is being detached from
+    target: {uuid: 'windowUuid', name: 'windowOne'}, // the identity of the window this BrowserView is attaching to
+    topic: "window",
+    type: "view-attached",
+    uuid: "AppUUID" // the UUID of the application this window belongs to.
+    viewIdentity: {uuid: 'viewUuid', name: 'viewName'}, // the identity of the BrowserView
+}
+```
+
+#### view-detached
+Generated when a window has a view detached from it.
+```js
+//This response has the following shape:
+{
+    name: "windowOne" // the name of this Window
+    previousTarget: {uuid: 'previousWindowUuid', name: 'previousWindowName'}, // the identity of the window this BrowserView is being detached from
+    target: {uuid: 'windowUuid', name: 'windowOne'}, // the identity of the window this BrowserView is attaching to
+    topic: "window",
+    type: "view-attached",
+    uuid: "AppUUID" // the UUID of the application this window belongs to.
+    viewIdentity: {uuid: 'viewUuid', name: 'viewName'}, // the identity of the BrowserView
 }
 ```
 


### PR DESCRIPTION

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

This PR adds the following events to Window:
- view-attached
- view-attached

These are not propagated events, they are emitted events from BrowserView.attach(). This is so that a window can know if it has a BrowserView attached to or detached from it, without having to listen to all created BrowserViews. This is also so that an application can know if its windows have BrowserViews attached to them that are not its own.

Tests:
https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5d8bd0157ba87401eaf56705

Related core PR:
https://github.com/HadoukenIO/core/pull/971

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [X] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [X] Link to new tests added
- [X] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
