### PR TITLE
RUN-5675 Can create a window with the name of a browserview

### DIFF
--- a/src/environment/openfin-env.ts
+++ b/src/environment/openfin-env.ts
@@ -36,8 +36,9 @@ export default class OpenFinEnvironment implements Environment {
                 return reject(new Error('Child window uuid must match the parent window\'s uuid: ' + parentUuid));
             }
 
-            if (this.isWindowExists(opt.uuid, opt.name)) {
-                return reject(new Error('Trying to create a window that already exists'));
+            if (fin.__internal_.entityExists(opt.uuid, opt.name)) {
+                return reject(new Error('Trying to create a Window with name-uuid combination already in use - ' +
+                    JSON.stringify({ name: opt.name, uuid: opt.uuid })));
             }
 
             // we should register the window name with the core asap to prevent


### PR DESCRIPTION
#### Description of Change
Checks if an identity provided for window creation is already in use.
To be merged after https://github.com/HadoukenIO/core/pull/984 is merged as these changes depend on it.

https://testing-dashboard.openfin.co/#/app/tests/5d97a73b36089855657ecf0a/edit

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers

#### Release Notes
Notes: Fixes the bug where one can create a window with the name of a BrowserView

@pbaize @datamadic @rdepena @MichaelMCoates 