### PR TITLE
RUN-5517 remove eval from webpack output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,8 @@ const webpackConfig = {
     output: {
         path: path.resolve(__dirname, 'out'),
         filename: 'js-adapter.js'
-    }
+    },
+    devtool: 'inline-source-map'
 };
 const serverParams = {
     root: path.resolve('html'),


### PR DESCRIPTION
#### Description of Change
Removes the eval calls from the web packed output of the js adapter

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [added](https://testing-dashboard.openfin.co/#/app/tests/5d9ca6c236089855657ecf87/edit)
- [ ] Integration tests added in this repo and in the [test dashboard](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is changed or added
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
