### PR TITLE
RUN-5637 Make 'send' and 'sendRaw' not accessible in channel API

### DIFF
--- a/src/api/interappbus/channel/channel.ts
+++ b/src/api/interappbus/channel/channel.ts
@@ -1,5 +1,5 @@
 import { Identity } from '../../../identity';
-import Transport, { Message } from '../../../transport/transport';
+import Transport from '../../../transport/transport';
 
 const idOrResult = (func: (...args: any[]) => any) => (...args: any[] ) => {
     const res = func(...args);
@@ -34,19 +34,19 @@ export class ChannelBase {
     private postAction: (...args: any[]) => any;
     private errorMiddleware: (...args: any[]) => any;
     private defaultSet: boolean;
-    protected send: (to: Identity, action: string, payload: any) => Promise<Message<void>>;
     protected providerIdentity: ProviderIdentity;
-    protected sendRaw: Transport['sendAction'];
 
-    constructor (providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
+    constructor (providerIdentity: ProviderIdentity, send: Transport['sendAction'], protecteds: any = {}) {
         this.defaultSet = false;
         this.providerIdentity = providerIdentity;
         this.subscriptions = new Map<string, () => any>();
         this.defaultAction = () => {
             throw new Error('No action registered');
         };
-        this.sendRaw = send;
-        this.send = async (to: Identity, action: string, payload: any) => {
+
+        // below two functions will be used by subclass. This is to avoid mistakenly attempt to use them from client side.
+        protecteds.sendRaw = send;
+        protecteds.send = async (to: Identity, action: string, payload: any) => {
             const raw = await send('send-channel-message', { ...to, providerIdentity: this.providerIdentity, action, payload })
             .catch(reason => {
                 throw new Error(reason.message);

--- a/src/api/interappbus/channel/channel.ts
+++ b/src/api/interappbus/channel/channel.ts
@@ -34,11 +34,9 @@ export class ChannelBase {
     private postAction: (...args: any[]) => any;
     private errorMiddleware: (...args: any[]) => any;
     private defaultSet: boolean;
-    protected providerIdentity: ProviderIdentity;
 
     constructor (providerIdentity: ProviderIdentity, send: Transport['sendAction'], superMap: WeakMap<ChannelBase, any>) {
         this.defaultSet = false;
-        this.providerIdentity = providerIdentity;
         this.subscriptions = new Map<string, () => any>();
         this.defaultAction = () => {
             throw new Error('No action registered');
@@ -46,9 +44,10 @@ export class ChannelBase {
 
         // The below two functions are only used by subclass, but not exposed to public. So a malicious site will not be able to use them.
         const protecteds: any = {};
+        protecteds.providerIdentity = providerIdentity;
         protecteds.sendRaw = send;
         protecteds.send = async (to: Identity, action: string, payload: any) => {
-            const raw = await send('send-channel-message', { ...to, providerIdentity: this.providerIdentity, action, payload })
+            const raw = await send('send-channel-message', { ...to, providerIdentity: protecteds.providerIdentity, action, payload })
             .catch(reason => {
                 throw new Error(reason.message);
             });

--- a/src/api/interappbus/channel/client.ts
+++ b/src/api/interappbus/channel/client.ts
@@ -1,19 +1,19 @@
-import { ChannelBase, ProviderIdentity } from './channel';
+import { ChannelBase, ProviderIdentity, ProtectedItems } from './channel';
 import Transport from '../../../transport/transport';
 
 type DisconnectionListener = (providerIdentity: ProviderIdentity) => any;
 
-const _supersMap: WeakMap<ChannelBase, any> = new WeakMap();
+const _clientProtectedMap: WeakMap<ChannelBase, ProtectedItems> = new WeakMap();
 export class ChannelClient extends ChannelBase {
     private disconnectListener: DisconnectionListener;
 
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
-        super(providerIdentity, send, _supersMap);
+        super(providerIdentity, send, _clientProtectedMap);
         this.disconnectListener = () => undefined;
     }
 
     public async dispatch(action: string, payload?: any): Promise<any> {
-        const protectedObj = _supersMap.get(this);
+        const protectedObj = _clientProtectedMap.get(this);
         return protectedObj.send(protectedObj.providerIdentity, action, payload);
     }
 
@@ -22,7 +22,7 @@ export class ChannelClient extends ChannelBase {
     }
 
     public async disconnect(): Promise<void> {
-        const protectedObj = _supersMap.get(this);
+        const protectedObj = _clientProtectedMap.get(this);
         const { channelName, uuid, name, channelId } = protectedObj.providerIdentity;
         await protectedObj.sendRaw('disconnect-from-channel', { channelName, uuid, name });
         this.removeChannel(channelId);

--- a/src/api/interappbus/channel/client.ts
+++ b/src/api/interappbus/channel/client.ts
@@ -3,17 +3,17 @@ import Transport from '../../../transport/transport';
 
 type DisconnectionListener = (providerIdentity: ProviderIdentity) => any;
 
-const _supers: any = {};
+const _supersMap: WeakMap<ChannelBase, any> = new WeakMap();
 export class ChannelClient extends ChannelBase {
     private disconnectListener: DisconnectionListener;
 
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
-        super(providerIdentity, send, _supers);
+        super(providerIdentity, send, _supersMap);
         this.disconnectListener = () => undefined;
     }
 
     public async dispatch(action: string, payload?: any): Promise<any> {
-        return _supers.send(this.providerIdentity, action, payload);
+        return _supersMap.get(this).send(this.providerIdentity, action, payload);
     }
 
     public onDisconnection(listener: DisconnectionListener): void {
@@ -22,7 +22,7 @@ export class ChannelClient extends ChannelBase {
 
     public async disconnect(): Promise<void> {
         const { channelName, uuid, name } = this.providerIdentity;
-        await _supers.sendRaw('disconnect-from-channel', { channelName, uuid, name });
+        await _supersMap.get(this).sendRaw('disconnect-from-channel', { channelName, uuid, name });
         const { channelId } = this.providerIdentity;
         this.removeChannel(channelId);
     }

--- a/src/api/interappbus/channel/client.ts
+++ b/src/api/interappbus/channel/client.ts
@@ -13,7 +13,8 @@ export class ChannelClient extends ChannelBase {
     }
 
     public async dispatch(action: string, payload?: any): Promise<any> {
-        return _supersMap.get(this).send(this.providerIdentity, action, payload);
+        const protectedObj = _supersMap.get(this);
+        return protectedObj.send(protectedObj.providerIdentity, action, payload);
     }
 
     public onDisconnection(listener: DisconnectionListener): void {
@@ -21,9 +22,9 @@ export class ChannelClient extends ChannelBase {
     }
 
     public async disconnect(): Promise<void> {
-        const { channelName, uuid, name } = this.providerIdentity;
-        await _supersMap.get(this).sendRaw('disconnect-from-channel', { channelName, uuid, name });
-        const { channelId } = this.providerIdentity;
+        const protectedObj = _supersMap.get(this);
+        const { channelName, uuid, name, channelId } = protectedObj.providerIdentity;
+        await protectedObj.sendRaw('disconnect-from-channel', { channelName, uuid, name });
         this.removeChannel(channelId);
     }
 }

--- a/src/api/interappbus/channel/client.ts
+++ b/src/api/interappbus/channel/client.ts
@@ -3,16 +3,17 @@ import Transport from '../../../transport/transport';
 
 type DisconnectionListener = (providerIdentity: ProviderIdentity) => any;
 
+const _supers: any = {};
 export class ChannelClient extends ChannelBase {
     private disconnectListener: DisconnectionListener;
 
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
-        super(providerIdentity, send);
+        super(providerIdentity, send, _supers);
         this.disconnectListener = () => undefined;
     }
 
     public async dispatch(action: string, payload?: any): Promise<any> {
-        return this.send(this.providerIdentity, action, payload);
+        return _supers.send(this.providerIdentity, action, payload);
     }
 
     public onDisconnection(listener: DisconnectionListener): void {
@@ -21,7 +22,7 @@ export class ChannelClient extends ChannelBase {
 
     public async disconnect(): Promise<void> {
         const { channelName, uuid, name } = this.providerIdentity;
-        await this.sendRaw('disconnect-from-channel', { channelName, uuid, name });
+        await _supers.sendRaw('disconnect-from-channel', { channelName, uuid, name });
         const { channelId } = this.providerIdentity;
         this.removeChannel(channelId);
     }

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -42,7 +42,7 @@ export class ChannelProvider extends ChannelBase {
     public async destroy(): Promise<void> {
         const protectedObj = _supersMap.get(this);
         const { channelName, channelId } = protectedObj.providerIdentity;
-        await protectedObj.get(this).sendRaw('destroy-channel', { channelName });
+        await protectedObj.sendRaw('destroy-channel', { channelName });
         this.removeChannel(channelId);
     }
 

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -1,25 +1,25 @@
-import { ChannelBase, ProviderIdentity } from './channel';
+import { ChannelBase, ProviderIdentity, ProtectedItems } from './channel';
 import Transport from '../../../transport/transport';
 import { Identity } from '../../../main';
 
 export type ConnectionListener = (identity: Identity, connectionMessage?: any) => any;
 export type DisconnectionListener = (identity: Identity) => any;
 
-const _supersMap: WeakMap<ChannelBase, any> = new WeakMap();
+const _providerProtectedMap: WeakMap<ChannelBase, ProtectedItems> = new WeakMap();
 export class ChannelProvider extends ChannelBase {
     private connectListener: ConnectionListener;
     private disconnectListener: ConnectionListener;
     public connections: Identity[];
 
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
-        super(providerIdentity, send, _supersMap);
+        super(providerIdentity, send, _providerProtectedMap);
         this.connectListener = () => undefined;
         this.disconnectListener = () => undefined;
         this.connections = [];
     }
 
     public dispatch(to: Identity, action: string, payload: any): Promise<any> {
-        return _supersMap.get(this).send(to, action, payload);
+        return _providerProtectedMap.get(this).send(to, action, payload);
     }
 
     public async processConnection(senderId: Identity, payload: any) {
@@ -28,7 +28,7 @@ export class ChannelProvider extends ChannelBase {
     }
 
     public publish(action: string, payload: any): Promise<any>[] {
-        return this.connections.map(to => _supersMap.get(this).send(to, action, payload));
+        return this.connections.map(to => _providerProtectedMap.get(this).send(to, action, payload));
     }
 
     public onConnection(listener: ConnectionListener): void {
@@ -40,7 +40,7 @@ export class ChannelProvider extends ChannelBase {
     }
 
     public async destroy(): Promise<void> {
-        const protectedObj = _supersMap.get(this);
+        const protectedObj = _providerProtectedMap.get(this);
         const { channelName, channelId } = protectedObj.providerIdentity;
         await protectedObj.sendRaw('destroy-channel', { channelName });
         this.removeChannel(channelId);

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -5,21 +5,21 @@ import { Identity } from '../../../main';
 export type ConnectionListener = (identity: Identity, connectionMessage?: any) => any;
 export type DisconnectionListener = (identity: Identity) => any;
 
-const _supers: any = {};
+const _supersMap: WeakMap<ChannelBase, any> = new WeakMap();
 export class ChannelProvider extends ChannelBase {
     private connectListener: ConnectionListener;
     private disconnectListener: ConnectionListener;
     public connections: Identity[];
 
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
-        super(providerIdentity, send, _supers);
+        super(providerIdentity, send, _supersMap);
         this.connectListener = () => undefined;
         this.disconnectListener = () => undefined;
         this.connections = [];
     }
 
     public dispatch(to: Identity, action: string, payload: any): Promise<any> {
-        return _supers.send(to, action, payload);
+        return _supersMap.get(this).send(to, action, payload);
     }
 
     public async processConnection(senderId: Identity, payload: any) {
@@ -28,7 +28,7 @@ export class ChannelProvider extends ChannelBase {
     }
 
     public publish(action: string, payload: any): Promise<any>[] {
-        return this.connections.map(to => _supers.send(to, action, payload));
+        return this.connections.map(to => _supersMap.get(this).send(to, action, payload));
     }
 
     public onConnection(listener: ConnectionListener): void {
@@ -41,7 +41,7 @@ export class ChannelProvider extends ChannelBase {
 
     public async destroy(): Promise<void> {
         const { channelName } = this.providerIdentity;
-        await _supers.sendRaw('destroy-channel', { channelName });
+        await _supersMap.get(this).sendRaw('destroy-channel', { channelName });
         const { channelId } = this.providerIdentity;
         this.removeChannel(channelId);
     }

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -5,20 +5,21 @@ import { Identity } from '../../../main';
 export type ConnectionListener = (identity: Identity, connectionMessage?: any) => any;
 export type DisconnectionListener = (identity: Identity) => any;
 
+const _supers: any = {};
 export class ChannelProvider extends ChannelBase {
     private connectListener: ConnectionListener;
     private disconnectListener: ConnectionListener;
     public connections: Identity[];
 
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
-        super(providerIdentity, send);
+        super(providerIdentity, send, _supers);
         this.connectListener = () => undefined;
         this.disconnectListener = () => undefined;
         this.connections = [];
     }
 
     public dispatch(to: Identity, action: string, payload: any): Promise<any> {
-        return this.send(to, action, payload);
+        return _supers.send(to, action, payload);
     }
 
     public async processConnection(senderId: Identity, payload: any) {
@@ -27,7 +28,7 @@ export class ChannelProvider extends ChannelBase {
     }
 
     public publish(action: string, payload: any): Promise<any>[] {
-        return this.connections.map(to => this.send(to, action, payload));
+        return this.connections.map(to => _supers.send(to, action, payload));
     }
 
     public onConnection(listener: ConnectionListener): void {
@@ -40,7 +41,7 @@ export class ChannelProvider extends ChannelBase {
 
     public async destroy(): Promise<void> {
         const { channelName } = this.providerIdentity;
-        await this.sendRaw('destroy-channel', { channelName });
+        await _supers.sendRaw('destroy-channel', { channelName });
         const { channelId } = this.providerIdentity;
         this.removeChannel(channelId);
     }

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -40,9 +40,9 @@ export class ChannelProvider extends ChannelBase {
     }
 
     public async destroy(): Promise<void> {
-        const { channelName } = this.providerIdentity;
-        await _supersMap.get(this).sendRaw('destroy-channel', { channelName });
-        const { channelId } = this.providerIdentity;
+        const protectedObj = _supersMap.get(this);
+        const { channelName, channelId } = protectedObj.providerIdentity;
+        await protectedObj.get(this).sendRaw('destroy-channel', { channelName });
         this.removeChannel(channelId);
     }
 


### PR DESCRIPTION
This PR is to make 'send' and 'sendRaw' not accessible in channel API so it's preventing  a malicious site bypassing the connection logic of a Channel instance and invoke actions.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
